### PR TITLE
Fix android tests to use local defined projectId

### DIFF
--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     id("com.google.gms.google-services")
@@ -14,7 +16,21 @@ android {
         versionCode = 1
         versionName = "1.0"
 
+        val localProperties = Properties()
+        val localPropertiesFile = rootProject.file("local.properties")
+        if (localPropertiesFile.exists()) {
+            localPropertiesFile.inputStream().use { localProperties.load(it) }
+        }
+
+        val firebaseProjectId = localProperties.getProperty("FIREBASE_PROJECT_ID")
+
+        buildConfigField("String", "FIREBASE_PROJECT_ID", "\"${firebaseProjectId}\"")
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 
     buildTypes {

--- a/code/app/src/androidTest/java/com/example/bread/HomeFilterUITest.java
+++ b/code/app/src/androidTest/java/com/example/bread/HomeFilterUITest.java
@@ -273,7 +273,7 @@ public class HomeFilterUITest {
     }
 
     private void clearFirestoreEmulator() {
-        String projectId = "project-db"; // Change to your project ID
+        String projectId = BuildConfig.FIREBASE_PROJECT_ID;
         String firestoreUrl = "http://10.0.2.2:8080/emulator/v1/projects/"
                 + projectId
                 + "/databases/(default)/documents";
@@ -296,7 +296,7 @@ public class HomeFilterUITest {
     }
 
     private void clearAuthEmulator() {
-        String projectId = "project-db"; // Change to your project ID
+        String projectId = BuildConfig.FIREBASE_PROJECT_ID;
         // This is the Auth emulator endpoint for deleting all test users
         String authUrl = "http://10.0.2.2:9099/emulator/v1/projects/"
                 + projectId

--- a/code/app/src/androidTest/java/com/example/bread/HomeFragmentActivityTest.java
+++ b/code/app/src/androidTest/java/com/example/bread/HomeFragmentActivityTest.java
@@ -129,7 +129,7 @@ public class HomeFragmentActivityTest {
     }
 
     private void clearFirestoreEmulator() {
-        String projectId = "project-db"; // Change to your project ID
+        String projectId = BuildConfig.FIREBASE_PROJECT_ID;
         String firestoreUrl = "http://10.0.2.2:8080/emulator/v1/projects/"
                 + projectId
                 + "/databases/(default)/documents";
@@ -152,7 +152,7 @@ public class HomeFragmentActivityTest {
     }
 
     private void clearAuthEmulator() {
-        String projectId = "project-db"; // Change to your project ID
+        String projectId = BuildConfig.FIREBASE_PROJECT_ID;
         // This is the Auth emulator endpoint for deleting all test users
         String authUrl = "http://10.0.2.2:9099/emulator/v1/projects/"
                 + projectId

--- a/code/app/src/androidTest/java/com/example/bread/MoodEventAddTest.java
+++ b/code/app/src/androidTest/java/com/example/bread/MoodEventAddTest.java
@@ -203,7 +203,7 @@ public class MoodEventAddTest {
 
     @After
     public void tearDownAuth() {
-        String projectId = "temp-bread";  //SET TO YOUR PROJECT ID
+        String projectId = BuildConfig.FIREBASE_PROJECT_ID;
         URL url = null;
         try {
             url = new URL("http://10.0.2.2:9099/emulator/v1/projects/"+projectId+"/accounts");
@@ -228,7 +228,7 @@ public class MoodEventAddTest {
 
     @After
     public void tearDownDb() {
-        String projectId = "temp-bread"; //SET TO YOUR PROJECT ID
+        String projectId = BuildConfig.FIREBASE_PROJECT_ID;
         URL url = null;
         try {
             url = new URL("http://10.0.2.2:8080/emulator/v1/projects/"+projectId+"/databases/(default)/documents");

--- a/code/app/src/androidTest/java/com/example/bread/MoodHistoryFragmentTest.java
+++ b/code/app/src/androidTest/java/com/example/bread/MoodHistoryFragmentTest.java
@@ -150,7 +150,7 @@ public class MoodHistoryFragmentTest {
 
     @After
     public void tearDownAuth() {
-        String projectId = "project-db"; //set to your project ID
+        String projectId = BuildConfig.FIREBASE_PROJECT_ID;
         URL url = null;
         try {
             url = new URL("http://10.0.2.2:9099/emulator/v1/projects/"+projectId+"/databases/%28default%29/documents");
@@ -175,7 +175,7 @@ public class MoodHistoryFragmentTest {
 
     @After
     public void tearDownDb() {
-        String projectId = "project-db"; //set to your project ID
+        String projectId = BuildConfig.FIREBASE_PROJECT_ID;
         URL url = null;
         try {
             url = new URL("http://10.0.2.2:8080/emulator/v1/projects/"+projectId+"/databases/%28default%29/documents");

--- a/code/app/src/androidTest/java/com/example/bread/SettingsPageTest.java
+++ b/code/app/src/androidTest/java/com/example/bread/SettingsPageTest.java
@@ -162,7 +162,7 @@ public class SettingsPageTest {
     }
 
     private void clearFirestoreEmulator() {
-        String projectId = "bread-2259c";
+        String projectId = BuildConfig.FIREBASE_PROJECT_ID;
         String firestoreUrl = "http://10.0.2.2:8080/emulator/v1/projects/"
                 + projectId
                 + "/databases/(default)/documents";
@@ -185,7 +185,7 @@ public class SettingsPageTest {
     }
 
     private void clearAuthEmulator() {
-        String projectId = "bread-2259c";
+        String projectId = BuildConfig.FIREBASE_PROJECT_ID;
         // This is the Auth emulator endpoint for deleting all test users
         String authUrl = "http://10.0.2.2:9099/emulator/v1/projects/"
                 + projectId


### PR DESCRIPTION
This PR effectively solves the issue where everyone is committing their own version of project id in the tests which will result in them not working on someones else machine.

To make them work add the below in `local.properties` file:
```
FIREBASE_PROJECT_ID=your-project-id
```
